### PR TITLE
fix: the clipboard/main in main.cpp

### DIFF
--- a/clipboard/main.cpp
+++ b/clipboard/main.cpp
@@ -6,6 +6,7 @@
 // Copyright(C) 2020 Chris Warren-Smith
 
 #include "config.h"
+#include <stdio.h>
 #include <string.h>
 
 #include "libclipboard/include/libclipboard.h"
@@ -31,7 +32,7 @@ int sblib_proc_count() {
 int sblib_proc_getname(int index, char *proc_name) {
   int result;
   if (index < sblib_proc_count()) {
-    strcpy(proc_name, "COPY");
+    snprintf(proc_name, 64, "COPY");
     result = 1;
   } else {
     result = 0;
@@ -58,7 +59,7 @@ int sblib_func_count() {
 int sblib_func_getname(int index, char *proc_name) {
   int result;
   if (index < sblib_func_count()) {
-    strcpy(proc_name, "PASTE");
+    snprintf(proc_name, 64, "PASTE");
     result = 1;
   } else {
     result = 0;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `clipboard/main.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `clipboard/main.cpp:34` |
| **CWE** | CWE-120 |

**Description**: The clipboard/main.cpp file uses unbounded strcpy() to copy strings into a fixed-size proc_name buffer at lines 34 and 61. While the specific string literals 'COPY' and 'PASTE' are constants and safe in isolation, the pattern establishes an unsafe coding practice and the buffer may be reused with attacker-controlled data in related code paths. The strcpy call provides no bounds checking against the destination buffer size, creating a stack buffer overflow risk whenever the source data is not a compile-time constant.

## Changes
- `clipboard/main.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
